### PR TITLE
adjust cron schedule to run at :13 and :43 instead of every 30 minutes on the dot

### DIFF
--- a/.github/workflows/backup-payload.yml
+++ b/.github/workflows/backup-payload.yml
@@ -2,7 +2,7 @@ name: Backup Payload Database to S3
 
 on:
     schedule:
-        - cron: "*/30 * * * *" # runs every 30 minutes
+        - cron: "13,43 * * * *" # runs every 30 minutes at hh:13 and hh:43
     workflow_dispatch: # allows manual triggering from GitHub UI
 
 permissions:


### PR DESCRIPTION
changed the cron schedule to `:13` and `:43` instead of every 30 mins to avoid GH Actions delays from peak traffic at the top of the hour, ensuring more consistent runs that are closer to the specified time