### PR TITLE
add explanatory description for entity graphic

### DIFF
--- a/src/app/(app)/(pages)/directory/(posts)/clubs/[club]/page.tsx
+++ b/src/app/(app)/(pages)/directory/(posts)/clubs/[club]/page.tsx
@@ -121,7 +121,7 @@ export default async function ClubPage({ params }: Props) {
             </div>
 
             {/* Club Graphic */}
-            {typeof club.graphic === "object" && club.graphic?.url && (
+            {club.graphicTitle && typeof club.graphic === "object" && club.graphic?.url && (
                 <div className="mt-6 flex h-full flex-col rounded-2xl border border-cBorder bg-cBackgroundOffset p-6 shadow-sm transition-all hover:shadow-md md:p-8">
                     <div className="flex flex-row items-center gap-2">
                         <FaImage />

--- a/src/app/(app)/(pages)/directory/(posts)/resources/[resource]/page.tsx
+++ b/src/app/(app)/(pages)/directory/(posts)/resources/[resource]/page.tsx
@@ -165,7 +165,7 @@ export default async function ResourcePage({ params }: Props) {
             </div>
 
             {/* Resource Graphic */}
-            {typeof resource.graphic === "object" && resource.graphic?.url && (
+            {resource.graphicTitle && typeof resource.graphic === "object" && resource.graphic?.url && (
                 <div className="mt-6 flex h-full flex-col rounded-2xl border border-cBorder bg-cBackgroundOffset p-6 shadow-sm transition-all hover:shadow-md md:p-8">
                     <div className="flex flex-row items-center gap-2">
                         <FaImage />

--- a/src/collections/lists/clubs/Clubs.ts
+++ b/src/collections/lists/clubs/Clubs.ts
@@ -137,6 +137,9 @@ export const Clubs: CollectionConfig = {
             access: {
                 update: canEditContent,
             },
+            admin: {
+                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection. ",
+            },
         },
         {
             name: "graphicTitleFr",

--- a/src/collections/lists/clubs/Clubs.ts
+++ b/src/collections/lists/clubs/Clubs.ts
@@ -138,7 +138,7 @@ export const Clubs: CollectionConfig = {
                 update: canEditContent,
             },
             admin: {
-                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection. ",
+                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection.",
             },
         },
         {

--- a/src/collections/lists/resources/Resources.ts
+++ b/src/collections/lists/resources/Resources.ts
@@ -228,7 +228,7 @@ export const Resources: CollectionConfig = {
                 update: canEditContent,
             },
             admin: {
-                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection. ",
+                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection.",
             },
         },
         {

--- a/src/collections/lists/resources/Resources.ts
+++ b/src/collections/lists/resources/Resources.ts
@@ -227,6 +227,9 @@ export const Resources: CollectionConfig = {
             access: {
                 update: canEditContent,
             },
+            admin: {
+                description: "This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection. ",
+            },
         },
         {
             name: "graphicTitleFr",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -311,6 +311,9 @@ export interface Club {
         id?: string | null;
       }[]
     | null;
+  /**
+   * This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection.
+   */
   graphicTitle?: string | null;
   graphicTitleFr?: string | null;
   /**
@@ -381,6 +384,9 @@ export interface Resource {
   channelTelephone?: boolean | null;
   channelInPerson?: boolean | null;
   onCampus?: boolean | null;
+  /**
+   * This field must be filled out before the option to add a graphic is shown. To remove the graphic, simply remove this field. If the graphic is not used elsewhere, please remember to delete it from the Media collection.
+   */
   graphicTitle?: string | null;
   graphicTitleFr?: string | null;
   /**


### PR DESCRIPTION
there was some confusion between editors on how to add a graphic, this PR adds a description to clarify
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add description for `graphicTitle` field in `Clubs` and `Resources` collections and update rendering logic in `page.tsx` files.
> 
>   - **Behavior**:
>     - Update `page.tsx` in `clubs` and `resources` to check `graphicTitle` before rendering graphics.
>   - **Models**:
>     - Add `admin.description` to `graphicTitle` in `Clubs.ts` and `Resources.ts` to clarify its necessity for displaying graphics.
>   - **Types**:
>     - Add comments to `graphicTitle` in `Club` and `Resource` interfaces in `payload-types.ts` to reflect new description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for e1899104cd2d36047896f718c6190b561838767d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->