### PR TITLE
fix(sec): replace tj-actions/changed-files with gh api

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -102,7 +102,28 @@ jobs:
 
             - name: Get changed files
               id: changed-files
-              uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Use gh api to get all changed files with pagination
+                  FILES=$(gh api graphql -f query='
+                    query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+                      repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $pr) {
+                          files(first: 100, after: $endCursor) {
+                            pageInfo{ hasNextPage, endCursor }
+                            nodes {
+                              path
+                            }
+                          }
+                        }
+                      }
+                    }' -F owner=${{ github.repository_owner }} -F repo=${{ github.event.repository.name }} -F pr=$PR_NUMBER --paginate --jq '.data.repository.pullRequest.files.nodes.[].path')
+
+                  # Convert newline-separated list to space-separated for Prettier
+                  FILES_SPACE_SEPARATED=$(echo "$FILES" | tr '\n' ' ')
+                  echo "all_changed_files=$FILES_SPACE_SEPARATED" >> $GITHUB_OUTPUT
 
             - name: Check Prettier formatting
               id: prettier

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -107,6 +107,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   # Use gh api to get all changed files with pagination
+                  # see https://github.com/cli/cli/issues/5368#issuecomment-1344253654
                   FILES=$(gh api graphql -f query='
                     query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
                       repository(owner: $owner, name: $repo) {


### PR DESCRIPTION

see `https://github.com/cli/cli/issues/5368#issuecomment-1344253654` for more info


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `tj-actions/changed-files` with a custom script using GitHub CLI to fetch changed files in `pr-checks.yml`.
> 
>   - **Behavior**:
>     - Replaces `tj-actions/changed-files` with a custom script using `gh api` in `pr-checks.yml`.
>     - Fetches changed files using GitHub GraphQL API with pagination.
>     - Converts newline-separated file list to space-separated for Prettier.
>   - **Environment Variables**:
>     - Uses `PR_NUMBER` and `GH_TOKEN` for API requests.
>   - **Output**:
>     - Outputs `all_changed_files` as space-separated list to `$GITHUB_OUTPUT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 5c8cf754d8863eb92c02727f7a0bb2e3e43d8581. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->