### PR TITLE
fix: format date of LastUpdatedSection to match mtl timezone

### DIFF
--- a/src/app/(app)/(pages)/directory/(posts)/clubs/[club]/page.tsx
+++ b/src/app/(app)/(pages)/directory/(posts)/clubs/[club]/page.tsx
@@ -135,7 +135,7 @@ export default async function ClubPage({ params }: Props) {
             {tags.length > 0 && <TagsSection tags={tags} />}
 
             {/* Last Updated */}
-            <LastUpdatedSection updatedAt={club.updatedAt} />
+            <LastUpdatedSection updatedAt={new Date(club.updatedAt)} />
         </Fragment>
     );
 }

--- a/src/app/(app)/(pages)/directory/(posts)/resources/[resource]/page.tsx
+++ b/src/app/(app)/(pages)/directory/(posts)/resources/[resource]/page.tsx
@@ -179,7 +179,7 @@ export default async function ResourcePage({ params }: Props) {
             {tags.length > 0 && <TagsSection tags={tags} />}
 
             {/* Last Updated */}
-            <LastUpdatedSection updatedAt={resource.updatedAt} />
+            <LastUpdatedSection updatedAt={new Date(resource.updatedAt)} />
         </Fragment>
     );
 }

--- a/src/app/(app)/(pages)/events/[event]/page.tsx
+++ b/src/app/(app)/(pages)/events/[event]/page.tsx
@@ -133,7 +133,7 @@ export default async function EventPage({ params }: PageProps) {
                         <FiArrowLeft className="h-5 w-5" />
                         Go back to Events
                     </Link>
-                    <LastUpdatedSection updatedAt={event.updatedAt} />
+                    <LastUpdatedSection updatedAt={new Date(event.updatedAt)} />
                 </div>
             </div>
         </Fragment>

--- a/src/app/(app)/components/LastUpdatedSection.tsx
+++ b/src/app/(app)/components/LastUpdatedSection.tsx
@@ -1,6 +1,8 @@
-export default function LastUpdatedSection({ updatedAt }: { updatedAt: string }) {
-    const date = new Date(updatedAt);
-    const formattedDate = date.toISOString().split("T")[0];
+import { formatInTimeZone } from "date-fns-tz";
+
+export default function LastUpdatedSection({ updatedAt }: { updatedAt: Date }) {
+    const montrealTz = "America/Toronto";
+    const formattedDate = formatInTimeZone(updatedAt, montrealTz, "yyyy-MM-dd");
 
     return (
         <div className="mt-6 flex justify-center text-cTextOffset">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `LastUpdatedSection` now formats dates in Montreal timezone, with `updatedAt` converted to `Date` in `ClubPage`, `ResourcePage`, and `EventPage`.
> 
>   - **Behavior**:
>     - `LastUpdatedSection` now formats `updatedAt` using Montreal timezone via `date-fns-tz`.
>     - Converts `updatedAt` from string to `Date` in `ClubPage`, `ResourcePage`, and `EventPage`.
>   - **Components**:
>     - `LastUpdatedSection` in `LastUpdatedSection.tsx` now accepts `Date` instead of `string` and uses `formatInTimeZone` for formatting.
>   - **Pages**:
>     - `ClubPage` in `page.tsx` converts `updatedAt` to `Date`.
>     - `ResourcePage` in `page.tsx` converts `updatedAt` to `Date`.
>     - `EventPage` in `page.tsx` converts `updatedAt` to `Date`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 9d8eb4a60b97a69f0b5ec5f39cd693b3232e81e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->