### PR TITLE
ci: enable concurrency to force single instance of playwright testing...

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ permissions:
 
 # ensures only one check per PR runs at a time
 concurrency:
-    group: pr-${{ github.event.pull_request.number }}
+    group: playwright-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    test:
+    test_e2e:
         timeout-minutes: 10
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,11 @@ on:
 permissions:
     contents: read
 
+# ensures only one check per PR runs at a time
+concurrency:
+    group: pr-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 jobs:
     test:
         timeout-minutes: 10

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ permissions:
 
 # ensures only one PR check per PR runs at a time
 concurrency:
-    group: pr-${{ github.event.pull_request.number }}
+    group: pr-checks-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
… at all times
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add concurrency control to GitHub Actions workflows to ensure single instance execution per PR.
> 
>   - **Concurrency Control**:
>     - Adds `concurrency` to `playwright.yml` with group `playwright-${{ github.event.pull_request.number }}` to ensure only one Playwright test runs per PR.
>     - Adds `concurrency` to `pr-checks.yml` with group `pr-checks-${{ github.event.pull_request.number }}` to ensure only one PR check runs per PR.
>   - **Job Renaming**:
>     - Renames job `test` to `test_e2e` in `playwright.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 118e785eb66779b5f726fa13c71d65c7cc0b3c39. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->