### PR TITLE
build(deps): upgrade nextjs 15.2.0 -> 15.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "cross-env": "^7.0.3",
                 "date-fns-tz": "^3.2.0",
                 "graphql": "^16.8.1",
-                "next": "15.2.0",
+                "next": "15.2.3",
                 "nextjs-toploader": "^3.7.15",
                 "payload": "^3.29.0",
                 "react": "19.0.0",
@@ -54,14 +54,14 @@
                 "@types/canvas-confetti": "^1.9.0",
                 "@types/mailchimp__mailchimp_marketing": "^3.0.21",
                 "@types/node": "^22.5.4",
-                "@types/react": "19.0.10",
+                "@types/react": "19.0.12",
                 "@types/react-dom": "19.0.4",
                 "@types/tar": "^6.1.13",
                 "@vitejs/plugin-react": "^4.3.4",
                 "autoprefixer": "^10.4.20",
                 "conventional-changelog-atom": "^5.0.0",
                 "eslint": "^9.16.0",
-                "eslint-config-next": "15.2.0",
+                "eslint-config-next": "15.2.3",
                 "git-format-staged": "^3.1.1",
                 "husky": "^8.0.3",
                 "jsdom": "^26.0.0",
@@ -4385,15 +4385,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.0.tgz",
-            "integrity": "sha512-eMgJu1RBXxxqqnuRJQh5RozhskoNUDHBFybvi+Z+yK9qzKeG7dadhv/Vp1YooSZmCnegf7JxWuapV77necLZNA==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.3.tgz",
+            "integrity": "sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.0.tgz",
-            "integrity": "sha512-jHFUG2OwmAuOASqq253RAEG/5BYcPHn27p1NoWZDCf4OdvdK0yRYWX92YKkL+Mk2s+GyJrmd/GATlL5b2IySpw==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.3.tgz",
+            "integrity": "sha512-eNSOIMJtjs+dp4Ms1tB1PPPJUQHP3uZK+OQ7iFY9qXpGO6ojT6imCL+KcUOqE/GXGidWbBZJzYdgAdPHqeCEPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4401,9 +4401,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.0.tgz",
-            "integrity": "sha512-rlp22GZwNJjFCyL7h5wz9vtpBVuCt3ZYjFWpEPBGzG712/uL1bbSkS675rVAUCRZ4hjoTJ26Q7IKhr5DfJrHDA==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
+            "integrity": "sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==",
             "cpu": [
                 "arm64"
             ],
@@ -4417,9 +4417,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
-            "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
+            "integrity": "sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==",
             "cpu": [
                 "x64"
             ],
@@ -4433,9 +4433,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
-            "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
+            "integrity": "sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4449,9 +4449,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
-            "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
+            "integrity": "sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4465,9 +4465,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
-            "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz",
+            "integrity": "sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==",
             "cpu": [
                 "x64"
             ],
@@ -4481,9 +4481,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
-            "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz",
+            "integrity": "sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==",
             "cpu": [
                 "x64"
             ],
@@ -4497,9 +4497,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
-            "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
+            "integrity": "sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4513,9 +4513,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
-            "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
+            "integrity": "sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==",
             "cpu": [
                 "x64"
             ],
@@ -6318,9 +6318,9 @@
             }
         },
         "node_modules/@types/react": {
-            "version": "19.0.10",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-            "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+            "version": "19.0.12",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
+            "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9283,13 +9283,13 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.2.0.tgz",
-            "integrity": "sha512-LkG0KKpinAoNPk2HXSx0fImFb/hQ6RnhSxTkpJFTkQ0SmnzsbRsjjN95WC/mDY34nKOenpptYEVvfkCR/h+VjA==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.2.3.tgz",
+            "integrity": "sha512-VDQwbajhNMFmrhLWVyUXCqsGPN+zz5G8Ys/QwFubfsxTIrkqdx3N3x3QPW+pERz8bzGPP0IgEm8cNbZcd8PFRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "15.2.0",
+                "@next/eslint-plugin-next": "15.2.3",
                 "@rushstack/eslint-patch": "^1.10.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
                 "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -12935,12 +12935,12 @@
             "license": "MIT"
         },
         "node_modules/next": {
-            "version": "15.2.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.2.0.tgz",
-            "integrity": "sha512-VaiM7sZYX8KIAHBrRGSFytKknkrexNfGb8GlG6e93JqueCspuGte8i4ybn8z4ww1x3f2uzY4YpTaBEW4/hvsoQ==",
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.2.3.tgz",
+            "integrity": "sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.2.0",
+                "@next/env": "15.2.3",
                 "@swc/counter": "0.1.3",
                 "@swc/helpers": "0.5.15",
                 "busboy": "1.6.0",
@@ -12955,14 +12955,14 @@
                 "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.2.0",
-                "@next/swc-darwin-x64": "15.2.0",
-                "@next/swc-linux-arm64-gnu": "15.2.0",
-                "@next/swc-linux-arm64-musl": "15.2.0",
-                "@next/swc-linux-x64-gnu": "15.2.0",
-                "@next/swc-linux-x64-musl": "15.2.0",
-                "@next/swc-win32-arm64-msvc": "15.2.0",
-                "@next/swc-win32-x64-msvc": "15.2.0",
+                "@next/swc-darwin-arm64": "15.2.3",
+                "@next/swc-darwin-x64": "15.2.3",
+                "@next/swc-linux-arm64-gnu": "15.2.3",
+                "@next/swc-linux-arm64-musl": "15.2.3",
+                "@next/swc-linux-x64-gnu": "15.2.3",
+                "@next/swc-linux-x64-musl": "15.2.3",
+                "@next/swc-win32-arm64-msvc": "15.2.3",
+                "@next/swc-win32-x64-msvc": "15.2.3",
                 "sharp": "^0.33.5"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "cross-env": "^7.0.3",
         "date-fns-tz": "^3.2.0",
         "graphql": "^16.8.1",
-        "next": "15.2.0",
+        "next": "15.2.3",
         "nextjs-toploader": "^3.7.15",
         "payload": "^3.29.0",
         "react": "19.0.0",
@@ -66,14 +66,14 @@
         "@types/canvas-confetti": "^1.9.0",
         "@types/mailchimp__mailchimp_marketing": "^3.0.21",
         "@types/node": "^22.5.4",
-        "@types/react": "19.0.10",
+        "@types/react": "19.0.12",
         "@types/react-dom": "19.0.4",
         "@types/tar": "^6.1.13",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "conventional-changelog-atom": "^5.0.0",
         "eslint": "^9.16.0",
-        "eslint-config-next": "15.2.0",
+        "eslint-config-next": "15.2.3",
         "git-format-staged": "^3.1.1",
         "husky": "^8.0.3",
         "jsdom": "^26.0.0",
@@ -90,7 +90,7 @@
         "node": "^18.20.2 || >=20.9.0"
     },
     "overrides": {
-        "@types/react": "19.0.10",
+        "@types/react": "19.0.12",
         "@types/react-dom": "19.0.4"
     }
 }


### PR DESCRIPTION
fyi the recent middleware vulnerability does not affect us since we 1. do not use middleware except on our i18n branch, and 2. are hosting on vercel, thus this is not a security update but just a general one
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade `next`, `eslint-config-next`, and `@types/react` to latest patch versions in `package.json`.
> 
>   - **Dependencies**:
>     - Upgrade `next` from `15.2.0` to `15.2.3` in `package.json`.
>     - Upgrade `eslint-config-next` from `15.2.0` to `15.2.3` in `package.json`.
>     - Upgrade `@types/react` from `19.0.10` to `19.0.12` in `devDependencies` and `overrides` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for ea3ff6db788ab50f56c77647a0680d0320d17e0a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->