### PR TITLE
fix: husky scripts should be POSIX compliant

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,3 @@
-echo "Validating commit message..." && npm run -s commitlint ${1} && echo "Validated."
+#!/bin/sh
+
+echo "Validating commit message..." && npm run -s commitlint "$1" && echo "Validated."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,10 +7,10 @@ OUTPUT=$(npx git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{
 STATUS=$?
 
 # if npx failed, abort with its output and exit code
-if [ $STATUS -ne 0 ]; then
+if [ "$STATUS" -ne 0 ]; then
   echo "Error running git-format-staged:"
   echo "$OUTPUT"
-  exit $STATUS
+  exit "$STATUS"
 fi
 
 # if no output, no files were formatted

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,6 +22,6 @@ echo "$OUTPUT" | awk '
     print file
   }
 ' | tee /dev/tty | wc -l | {
-  read count
+  read -r count
   echo "Formatted $count files."
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,12 @@
 
 echo "Formatting files..."
 
-# Run git-format-staged and capture its output
+# run git-format-staged and capture its output
+command -v npx >/dev/null 2>&1 || {
+  echo >&2 "Error: npx is not installed or not in PATH. Please install Node.js and ensure it is available in your PATH.";
+  exit 3;
+}
+
 OUTPUT=$(npx git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{}"' '*')
 STATUS=$?
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,14 @@ echo "Formatting files..."
 
 # Run git-format-staged and capture its output
 OUTPUT=$(npx git-format-staged -f 'prettier --ignore-unknown --stdin-filepath "{}"' '*')
+STATUS=$?
+
+# if npx failed, abort with its output and exit code
+if [ $STATUS -ne 0 ]; then
+  echo "Error running git-format-staged:"
+  echo "$OUTPUT"
+  exit $STATUS
+fi
 
 # if no output, no files were formatted
 if [ -z "$OUTPUT" ]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,8 +12,16 @@ if [ -z "$OUTPUT" ]; then
 fi
 
 # extract filenames and count them, then output cleanly
-echo "$OUTPUT" | while read -r line; do
-  if [[ $line =~ Reformatted[[:space:]](.+)[[:space:]]with ]]; then
-    echo "${BASH_REMATCH[1]}"
-  fi
-done | tee /dev/tty | wc -l | { read count; echo "Formatted $count files."; }
+
+echo "$OUTPUT" | awk '
+  /Reformatted/ && /with/ {
+    for (i=1; i<=NF; i++) {
+      if ($i == "Reformatted") file=$(i+1)
+      if ($i == "with") break
+    }
+    print file
+  }
+' | tee /dev/tty | wc -l | {
+  read count
+  echo "Formatted $count files."
+}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-while read -r local_ref local_sha; do
+while read -r local_ref local_sha remote_ref remote_sha; do
     # skip master branch
     if [ "$local_ref" = "refs/heads/master" ]; then
         continue

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,7 +18,7 @@ while read local_ref local_sha remote_ref remote_sha; do
     fi
 
     # check if there are any commits unique to this branch
-    if [ -z "$(git rev-list $local_sha ^master)" ]; then
+    if [ -z "$(git rev-list "$local_sha" ^master)" ]; then
         echo "ERROR: Branch '${local_ref#refs/heads/}' has no unique commits"
         echo "Please create a commit before pushing this branch."
         exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-while read local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha; do
     # skip master branch
     if [ "$local_ref" = "refs/heads/master" ]; then
         continue


### PR DESCRIPTION
- `pre-commit` script had bash specific features, removed and using awk
- wrapped variables with quotes where necessary
- added shebang to `commit-msg`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make Husky scripts POSIX compliant by removing bash-specific features and adding error handling.
> 
>   - **POSIX Compliance**:
>     - Added shebang `#!/bin/sh` to `.husky/commit-msg`.
>     - Replaced bash-specific regex handling with `awk` in `.husky/pre-commit`.
>     - Quoted variables in `.husky/pre-push` to ensure proper handling.
>   - **Error Handling**:
>     - Added check for `npx` availability in `.husky/pre-commit` and exit with error if not found.
>     - Improved error messages for failed `git-format-staged` execution in `.husky/pre-commit`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 25de9f5afeece16b4557caf96d703eaf1b29069d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->