### PR TITLE
fix: allow manual triggering of PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches:
             - "**"
+    workflow_dispatch: # allows manual triggering from GitHub UI
 
 permissions:
     contents: write


### PR DESCRIPTION
PRs from forks need manual triggering within the repository for certain actions to be performed, like deployment and PR comments

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `workflow_dispatch` to allow manual triggering of PR checks for forked PRs.
> 
>   - **Behavior**:
>     - Adds `workflow_dispatch` to `.github/workflows/pr-checks.yml` to allow manual triggering of PR checks from the GitHub UI.
>     - Necessary for PRs from forks to perform actions like deployment and PR comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for cc489b4c32770e0b220eb419eae79ab8ee5d1ee4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->