### PR TITLE
fix: run PR checks on dependabot branches

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches:
             - "**"
+    push:
+        branches:
+            - "dependabot/**"
 
 permissions:
     contents: write


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `push` event trigger for `dependabot/**` branches in GitHub Actions to run PR checks.
> 
>   - **Workflow Trigger**:
>     - Adds `push` event trigger for branches matching `dependabot/**` in `.github/workflows/pr-checks.yml` to run PR checks on dependabot branches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 6decd922c823d4f7db2defe10fe63b142ae74c4c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->