### PR TITLE
fix: use workflow_dispatch to manually trigger PR checks from forks

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         environment:
             name: Preview
-            url: ${{ steps.deploy.outputs.url }}
+            url: ${{ steps.deploy-preview.outputs.url }}
 
         steps:
             - name: Checkout PR code

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,9 +1,7 @@
 name: Deploy
 
 on:
-    push:
-        branches: [master]
-    workflow_call: # to be called by pr-checks.yml
+    workflow_call:
         secrets:
             VERCEL_TOKEN:
                 required: true
@@ -11,7 +9,13 @@ on:
                 required: true
             VERCEL_PROJECT_ID:
                 required: true
+
     workflow_dispatch: # manual triggering for external fork PRs
+        inputs:
+            pr_number:
+                description: "Pull Request Number"
+                required: true
+                type: number
 
 permissions:
     contents: read
@@ -19,35 +23,42 @@ permissions:
 
 # ensures only one deployment per ref/branch runs at a time
 concurrency:
-    group: deploy-${{ github.ref }}
+    group: deploy-preview-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    deploy:
-        name: Deploy to ${{ github.ref == 'refs/heads/master' && 'Production' || 'Preview' }}
+    deploy_preview:
+        name: Deploy Preview
         runs-on: ubuntu-latest
         environment:
-            name: ${{ github.ref == 'refs/heads/master' && 'Production' || 'Preview' }}
+            name: Preview
             url: ${{ steps.deploy.outputs.url }}
 
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout PR code
+              uses: actions/checkout@v4
+              with:
+                  # fetch the PR's head (fork) code by PR number
+                  ref: refs/pull/${{ inputs.pr_number }}/merge
+                  repository: ${{ github.repository }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install Vercel CLI
               run: npm install --global vercel@latest
 
             - name: Pull Vercel Environment Information
-              run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/master' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
             - name: Build Project Artifacts
-              run: vercel build ${{ github.ref == 'refs/heads/master' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+              run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
             - name: Deploy Project Artifacts to Vercel
-              id: deploy
-              run: |
-                  DEPLOYMENT_URL=$(vercel deploy --prebuilt ${{ github.ref == 'refs/heads/master' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
-                  echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+              id: deploy-preview
               env:
                   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
                   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+              run: |
+                  DEPLOYMENT_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+                  echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
         environment:
             name: Production
-            url: ${{ steps.deploy.outputs.url }}
+            url: ${{ steps.deploy-prod.outputs.url }}
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,44 @@
+name: Deploy to Production
+
+on:
+    push:
+        branches: [master]
+    workflow_dispatch: # manual triggering for external fork PRs
+
+permissions:
+    contents: read
+    deployments: write
+
+concurrency:
+    group: deploy-production
+    cancel-in-progress: true
+
+jobs:
+    deploy_prod:
+        name: Deploy for Production
+        runs-on: ubuntu-latest
+        environment:
+            name: Production
+            url: ${{ steps.deploy.outputs.url }}
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install Vercel CLI
+              run: npm install --global vercel@latest
+
+            - name: Pull Vercel Environment Information
+              run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+            - name: Build Project Artifacts
+              run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+            - name: Deploy Project Artifacts to Vercel
+              id: deploy-prod
+              env:
+                  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+                  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+                  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+              run: |
+                  DEPLOYMENT_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+                  echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -201,8 +201,12 @@ jobs:
                         body
                       });
 
-    deploy:
-        uses: ./.github/workflows/deploy.yml
+    deploy_preview:
+        # runs only for internal PRs, i.e. if PR's head repo is the same as the base repo
+        # job is skipped otherwise, i.e. do not run for forked PRs
+        # forked PRs require a workflow_trigger of deploy-preview.yml
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: ./.github/workflows/deploy-preview.yml
         secrets:
             VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
             VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -206,7 +206,7 @@ jobs:
         # job is skipped otherwise, i.e. do not run for forked PRs
         # forked PRs require a workflow_trigger of deploy-preview.yml
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: ./.github/workflows/deploy-preview.yml
+        uses: ./.github/workflows/deploy-preview.yml\n        with: { pr_number: ${{ github.event.pull_request.number }} }
         secrets:
             VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
             VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -206,7 +206,9 @@ jobs:
         # job is skipped otherwise, i.e. do not run for forked PRs
         # forked PRs require a workflow_trigger of deploy-preview.yml
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: ./.github/workflows/deploy-preview.yml\n        with: { pr_number: ${{ github.event.pull_request.number }} }
+        uses: ./.github/workflows/deploy-preview.yml
+        with:
+            pr_number: ${{ github.event.pull_request.number }}
         secrets:
             VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
             VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
I'm writing a post about this and will edit this comment to include it in a bit (very busy w/ finals season rn so it'll likely be after that)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR introduces `workflow_dispatch` for manual PR check triggers from forks, separates deployment workflows into `deploy-preview.yml` and `deploy-prod.yml`, and updates `pr-checks.yml` for internal PR handling.
> 
>   - **Workflows**:
>     - Rename `deploy.yml` to `deploy-preview.yml` and modify it to use `workflow_dispatch` for manual triggering from forks.
>     - Add `deploy-prod.yml` for production deployments triggered on `master` branch pushes and manual triggers.
>     - Update `pr-checks.yml` to use `deploy-preview.yml` for internal PRs and provide instructions for forked PRs.
>   - **Jobs**:
>     - In `deploy-preview.yml`, add `pr_number` input for fetching PR code and adjust job names and environment settings.
>     - In `deploy-prod.yml`, set up production deployment with concurrency control and environment settings.
>   - **Misc**:
>     - Adjust concurrency group names in `deploy-preview.yml` and `deploy-prod.yml` to reflect their specific purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 4b1699b178ed88cb6b3159c7c4d2312c14ffbc1d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->