### PR TITLE
fix: fix for #140, do not depend on PR input

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on:
+    # called by pr-checks.yml only if on base repository (skips for forks)
     workflow_call:
         secrets:
             VERCEL_TOKEN:
@@ -28,6 +29,7 @@ concurrency:
 
 jobs:
     deploy_preview:
+        timeout-minutes: 10
         name: Deploy Preview
         runs-on: ubuntu-latest
         environment:
@@ -35,11 +37,11 @@ jobs:
             url: ${{ steps.deploy-preview.outputs.url }}
 
         steps:
-            - name: Checkout PR code
-              uses: actions/checkout@v4
+            - uses: actions/checkout@v4
               with:
-                  # fetch the PR's head (fork) code by PR number
-                  ref: refs/pull/${{ inputs.pr_number }}/merge
+                  # for workflow_dispatch (fork PRs), use PR number
+                  # for workflow_call (base repo), use branch ref
+                  ref: ${{ inputs.pr_number != null && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref }}
                   repository: ${{ github.repository }}
                   token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
     deploy_prod:
+        timeout-minutes: 10
         name: Deploy for Production
         runs-on: ubuntu-latest
         environment:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
     validate_commits:
+        timeout-minutes: 3
         name: Validate Commits
         runs-on: ubuntu-latest
         steps:
@@ -87,6 +88,7 @@ jobs:
                       });
 
     check_formatting:
+        timeout-minutes: 3
         name: Check Formatting
         runs-on: ubuntu-latest
         steps:
@@ -207,8 +209,6 @@ jobs:
         # forked PRs require a workflow_trigger of deploy-preview.yml
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: ./.github/workflows/deploy-preview.yml
-        with:
-            pr_number: ${{ github.event.pull_request.number }}
         secrets:
             VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
             VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
- fixes #140's `deploy-preview.yml` being dependent on a PR number input. now defaults to branch if from base repo, otherwise uses PR number to find forked branch
- additionally added `timeout-minutes` for all jobs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes #140 by removing PR number dependency in `deploy-preview.yml` and adding timeouts to all jobs.
> 
>   - **Behavior**:
>     - `deploy-preview.yml` now defaults to branch ref if from base repo, uses PR number for forked branches.
>     - Removes `pr_number` input dependency in `pr-checks.yml`.
>   - **Timeouts**:
>     - Adds `timeout-minutes: 10` to `deploy_preview` in `deploy-preview.yml` and `deploy_prod` in `deploy-prod.yml`.
>     - Adds `timeout-minutes: 3` to `validate_commits` and `check_formatting` in `pr-checks.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for ef98fd78865d08190297991af3f610974d00c27a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->