### PR TITLE
fix: rename workflow 'Deploy' -> 'Deploy to Preview'

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,6 @@ concurrency:
 jobs:
     deploy_preview:
         timeout-minutes: 10
-        name: Deploy Preview
         runs-on: ubuntu-latest
         environment:
             name: Preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy to Preview
 
 on:
     # called by pr-checks.yml only if on base repository (skips for forks)

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
     deploy_preview:
         timeout-minutes: 10
+        name: Deploy for Preview
         runs-on: ubuntu-latest
         environment:
             name: Preview

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
     deploy_prod:
         timeout-minutes: 10
+        name: Deploy for Production
         runs-on: ubuntu-latest
         environment:
             name: Production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
     deploy_prod:
         timeout-minutes: 10
-        name: Deploy for Production
         runs-on: ubuntu-latest
         environment:
             name: Production


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames workflow and job names in `.github/workflows/deploy-preview.yml` to clarify deployment to preview environment.
> 
>   - **Workflow Renaming**:
>     - Renames workflow `name` from `Deploy` to `Deploy to Preview` in `.github/workflows/deploy-preview.yml`.
>     - Renames job `name` from `Deploy Preview` to `Deploy for Preview` in the same file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 2ac0ae536ce775d171ef747ac9d5ff0781228d53. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->