### PR TITLE
refactor: rename deployment jobs to match their workflows

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
     deploy_preview:
         timeout-minutes: 10
-        name: Deploy for Preview
+        name: Deploy to Preview
         runs-on: ubuntu-latest
         environment:
             name: Preview

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
     deploy_prod:
         timeout-minutes: 10
-        name: Deploy for Production
+        name: Deploy to Production
         runs-on: ubuntu-latest
         environment:
             name: Production


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename deployment job names in GitHub Actions workflows to better match their workflows.
> 
>   - **Workflows**:
>     - Rename job `Deploy for Preview` to `Deploy to Preview` in `deploy-preview.yml`.
>     - Rename job `Deploy for Production` to `Deploy to Production` in `deploy-prod.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for e639d91ab7906e0b5bedbf608c3703157dc016b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->