### PR TITLE
fix(ci): notify success via github script

### DIFF
--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -8,11 +8,14 @@ permissions:
     contents: write
     pull-requests: write
     issues: write
+    actions: write
 
 jobs:
     cleanup_staging:
         name: Cleanup Staging Environment
         runs-on: ubuntu-latest
+        outputs:
+            redirect_deleted: ${{ steps.delete-redirect.outputs.success }}
         env:
             PR_NUMBER: ${{ github.event.pull_request.number }}
         steps:
@@ -64,10 +67,10 @@ jobs:
                   fi
 
             - name: Delete redirect rule
+              id: delete-redirect
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   echo "Looking up redirect rule for PR #${PR_NUMBER}..."
 
@@ -128,15 +131,7 @@ jobs:
                                           SUCCESS=$(echo "$RESPONSE_BODY" | jq -r '.success')
                                           if [ "$SUCCESS" = "true" ]; then
                                               echo "Successfully removed redirect rule for PR #${PR_NUMBER}."
-                                              # use github-script action for reliable PR commenting
-                                              echo "::group::Creating PR comment"
-                                              echo 'await github.rest.issues.createComment({
-                                                owner: context.repo.owner,
-                                                repo: context.repo.repo,
-                                                issue_number: '"${PR_NUMBER}"',
-                                                body: "🧹 PR closed or merged. Staging URL has been deleted."
-                                              });' | npx -p @actions/github-script github-script --script-stdin || echo "ERROR: Failed to comment on PR. Skipping..."
-                                              echo "::endgroup::"
+                                              echo "success=true" >> $GITHUB_OUTPUT
                                               break 2 # exit both loops on success
                                           fi
                                       elif [ "$HTTP_STATUS" -eq 412 ] && [ "$attempt" -lt "$MAX_RETRIES" ]; then
@@ -208,3 +203,21 @@ jobs:
                           console.log(`Failed to delete artifact ${artifact.id}: ${error.message}`);
                         }
                       }
+
+    notify_success:
+        needs: cleanup_staging
+        if: needs.cleanup_staging.outputs.redirect_deleted == 'true'
+        runs-on: ubuntu-latest
+        env:
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+        steps:
+            - name: Comment on PR
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.createComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        body: 'PR closed or merged. Staging URL has been deleted.'
+                      });


### PR DESCRIPTION
additionally add `actions: write` permission for artifact deletion
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `actions: write` permission and `notify_success` job to `cleanup-pr.yml` for commenting on PR upon successful redirect deletion.
> 
>   - **Permissions**:
>     - Adds `actions: write` permission in `cleanup-pr.yml` for artifact deletion.
>   - **Jobs**:
>     - Adds `notify_success` job in `cleanup-pr.yml` to comment on PR if `redirect_deleted` is true.
>     - Modifies `cleanup_staging` job to output `redirect_deleted` status and remove inline PR comment creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=atlasgong%2Fmindvista&utm_source=github&utm_medium=referral)<sup> for 140b1a6ad6a4b46fc8645142a63768698ae92d41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->